### PR TITLE
adjust banner padding

### DIFF
--- a/src/common/styles/global.css
+++ b/src/common/styles/global.css
@@ -93,11 +93,18 @@ body {
 
 .ukraine {
     text-align: start;
+    padding: 1rem;
 }
 
 @media (min-width: 415px) {
     .ukraine {
         text-align: center;
+    }
+}
+
+@media (max-width: 768px) {
+    .ukraine {
+        padding: 1.5rem;
     }
 }
 


### PR DESCRIPTION
Gjeller dette [kortet](https://trello.com/c/mlmNlxmP/590-bannere-sommerjobb-og-ukraina)

```
Sommerjobb
Fikse på padding (skal være 1.5 på mobil) og legge til focus state

Ukraina
Padding 1.5rem 1rem
```
Virker som sommerjobb banner er tatt bort så bare fikset ukraina banner