### PR TITLE
Presisering av hvordan man får tilgang til https://npm.pkg.github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,23 @@ npm run dev
 
 ### Hvordan få tilgang til @navikt/arbeidsplassen-react og @navikt/arbeidsplassen-css
 
-Opprett fila `.npmrc` i hjemkatalogen din f.eks. `~/.npmrc` Mer info: https://docs.npmjs.com/cli/v9/configuring-npm/npmrc
+1. Opprett fila `.npmrc` i hjemkatalogen din f.eks. `~/.npmrc` [Mer info.](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc)
 
-Legg til følgende i fila
+2. Legg til følgende i fila
 
 ```
 @navikt:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=$TOKEN
+//npm.pkg.github.com/:_authToken=${GH_TOKEN}
 ```
 
-Opprett et token med "read:packages" rettigheter. [https://github.com/settings/tokens](https://github.com/settings/tokens) Bytt ut \$TOKEN med tokenet du akkurat opprettet. Velg Authorize token under "Configure SSO" for å gi tokenet tilgang til @navikt.
+3. Bruk ditt eksisterende github-token, eller opprett et nytt med "read:packages" rettigheter [hos Github](https://github.com/settings/tokens). Husk å velg Authorize token under "Configure SSO" for å gi tokenet tilgang til @navikt.
+   Putt dette tokenet i en miljøvariabel med navnet `GH_TOKEN`, kan f.eks. gjøres i `~/.bashrc` eller `~/.zshrc`.
 
-Ikke sjekk inn `.npmrc` til GitHub.
+```
+export GH_TOKEN=<ditt github token>
+```
+
+4. Start en ny terminal, eller kjør `source ~/.bashrc` eller `source ~/.zshrc` for å laste inn miljøvariabelen.
 
 ### Deployment
 


### PR DESCRIPTION
Gjort det tydelig at hvis tokenet skal leses fra en miljøvariabel, i `.npmrc`, så må kan bruke krøllparentes rundt miljøvariabelen.