### PR TITLE
Fjerner lenken til de gamle vilkårene, siden disse kun er aktuelle for public-feed

### DIFF
--- a/src/modules/vilkar-api/VilkarApi.jsx
+++ b/src/modules/vilkar-api/VilkarApi.jsx
@@ -115,11 +115,6 @@ export default function VilkarApi() {
                 Har du spørsmål kan du kontakte oss på e-post{" "}
                 <AkselLink href="mailto:nav.team.arbeidsplassen@nav.no">nav.team.arbeidsplassen@nav.no</AkselLink>.
             </BodyLong>
-            <BodyLong className="mb-24">
-                <AkselLink as={NextLink} href="/vilkar-api-gammel">
-                    Gamle vilkår for bruk av API for stillingsannonser på arbeidsplassen.no
-                </AkselLink>
-            </BodyLong>
         </article>
     );
 }


### PR DESCRIPTION
Public-feed lenker selv direkte til de gamle vilkårene.

Ref diskusjonen i [slack-tråden](https://nav-it.slack.com/archives/C02UJQ9LY10/p1713782330804669).